### PR TITLE
Keep the aspect ratio through ImageOps.fit

### DIFF
--- a/nasa_apod_desktop.py
+++ b/nasa_apod_desktop.py
@@ -128,7 +128,7 @@ def resize_image(filename):
     image = Image.open(filename)
     if SHOW_DEBUG:
         print "Resizing the image to", RESOLUTION_X, 'x', RESOLUTION_Y
-    image = ImageOps.fit(image, (RESOLUTION_X, RESOLUTION_Y), Image.ANTIALIAS, 0, (0.5, 0.5IALIAS)
+    image = ImageOps.fit(image, (RESOLUTION_X, RESOLUTION_Y), Image.ANTIALIAS, 0, (0.5, 0.5))
 
     if SHOW_DEBUG:
         print "Saving the image to", filename

--- a/nasa_apod_desktop.py
+++ b/nasa_apod_desktop.py
@@ -69,7 +69,7 @@ import urllib
 import urllib2
 import re
 import os
-from PIL import Image
+from PIL import Image, ImageOps
 from sys import stdout
 
 # Configurable settings:
@@ -128,7 +128,7 @@ def resize_image(filename):
     image = Image.open(filename)
     if SHOW_DEBUG:
         print "Resizing the image to", RESOLUTION_X, 'x', RESOLUTION_Y
-    image = image.resize((RESOLUTION_X, RESOLUTION_Y), Image.ANTIALIAS)
+    image = ImageOps.fit(image, (RESOLUTION_X, RESOLUTION_Y), Image.ANTIALIAS, 0, (0.5, 0.5IALIAS)
 
     if SHOW_DEBUG:
         print "Saving the image to", filename


### PR DESCRIPTION
With the use of ImageOps.fit the aspect ratio of the picture isn't distorted. This cuts off (in a pretty dumb way) that is outside of the center.
A better approach might be something based on image entropy to cut out "uninteresting" parts of the images. Reddit uses a setup similar to this to make good thumbnails.
