### PR TITLE
Download path, window geometry discovery, plus wallpaper setting on XFCE4

### DIFF
--- a/nasa_apod_desktop.py
+++ b/nasa_apod_desktop.py
@@ -71,7 +71,9 @@ import re
 import os
 import sys
 import subprocess
+import logging
 
+LOG = logging.getLogger(__name__)
 # Configurable settings:
 NASA_APOD_SITE = 'http://apod.nasa.gov/apod/'
 SHOW_DEBUG = False
@@ -94,6 +96,8 @@ def get_image(text):
     if SHOW_DEBUG:
         print "Grabbing the image URL"
     reg = re.search('<a href="(image.*?)"', text, re.DOTALL)
+    if not reg:
+        LOG.error('cannot find image url in %r', text)
     if 'http' in reg.group(1):
         # Actual url
         file_url = reg.group(1)
@@ -237,6 +241,12 @@ def get_default_download_path():
 
 if __name__ == '__main__':
     ''' Our program '''
+    logging.basicConfig(level=logging.DEBUG)
+
+    if not 'XAUTHORITY' in os.environ:
+        os.environ['DISPLAY'] = ':0.0'
+        os.environ['XAUTHORITY'] = os.path.expandvars('$HOME/.Xauthority')
+
     if not (RESOLUTION_X and RESOLUTION_Y):
         RESOLUTION_X, RESOLUTION_Y = get_desktop_geometry()
     if not DOWNLOAD_PATH:


### PR DESCRIPTION
1. Add flags for command-line overriding of download path, image size and SHOW_DEBUG.
2. get default download path from glib, if importable - otherwise use $HOME/Downloads
3. get default image size using xprop (I think it exists on every X11)
4. format flake8-compatible.
