### PR TITLE
Fix for first run of the script and if a non-picture is encountered while  building the library

### DIFF
--- a/nasa_apod_desktop.py
+++ b/nasa_apod_desktop.py
@@ -420,7 +420,6 @@ if __name__ == '__main__':
 
     # Create the desktop switching xml
     filename = create_desktop_background_scoll(filename)
-    filename = None
     # If the script was unable todays image and IMAGE_SCROLL is set to False,
     # the script exits
     if filename is None:


### PR DESCRIPTION
Hi,
some changes:
- The script failed me the first time, fixed this with a recalculation of the number of images in the directory.
- An indent fix.
- The script will now continue if a non-picture is encountered while building the library of pictures.
- Some extra safety in the main function, if today's picture is a non-picture and IMAGE_SCROLL is set to False.

Thanks for a good script!
